### PR TITLE
Tests to show that as far as I can see configure does not work properly

### DIFF
--- a/spec/mongodb_spec.rb
+++ b/spec/mongodb_spec.rb
@@ -1,14 +1,31 @@
 require File.join(File.dirname(__FILE__), 'spec_helper.rb')
 
 class MongodbManifest < Moonshine::Manifest
-  plugin :mongodb
+  include Mongodb
+  configure(:mongodb => {:version => '1.5', :auth => true, :master? => true })
+  recipe :mongodb
 end
 
 describe "A manifest with the Mongodb plugin" do
   
   before do
     @manifest = MongodbManifest.new
-    @manifest.mongodb
+    @manifest.send(:evaluate_recipes)
+  end
+  
+  it "should use the version specified" do
+    # should not include the default
+    @manifest.files['/etc/init.d/mongodb'].content.should_not =~ %r{mongo-1.4.4/bin/mongod}
+    # but rather use our own custom version
+    @manifest.files['/etc/init.d/mongodb'].content.should =~ %r{mongo-1.5/bin/mongod}
+  end
+  
+  it "should require auth" do
+    @manifest.files['/etc/init.d/mongodb'].content.should =~ /--auth/
+  end
+  
+  it "should be a master" do
+    @manifest.files['/etc/init.d/mongodb'].content.should =~ /--master/
   end
   
   it "should be executable" do


### PR DESCRIPTION
The issue is when mongodb (the method) merges the passed in hash (HashWithIndifferentAccess) into it's options hash... that results in a normal hash with mixed string/symbol semantics (and all the HashWithIndifferentAccess keys are merged as strings).
