### PR TITLE
Fully Trusty and Mongodb 2.6.x support.

### DIFF
--- a/lib/mongodb.rb
+++ b/lib/mongodb.rb
@@ -122,6 +122,13 @@ module Mongodb
           :require => [ exec('apt-get update'), package('mongodb-10gen') ]
 
         package 'mongodb-10gen', :ensure => :absent
+      elsif options[:version] =~ /^2.6.*$/
+        package 'mongodb-org',
+          :ensure => options[:version],
+          :alias => 'mongodb',
+          :require => [ exec('apt-get update'), package('mongodb-10gen') ]
+        
+        package 'mongodb-10gen', :ensure => :absent
       else
         package 'mongodb-10gen',
           :ensure => options[:version],
@@ -131,35 +138,41 @@ module Mongodb
         package 'mongodb18-10gen', :ensure => :absent
       end
 
-      file '/etc/mongodb.conf',
+      mongod_name = if options[:version] =~ /^2.6.*$/
+        'mongod'
+      else
+        'mongodb'
+      end
+
+      file "/etc/#{mongod_name}.conf",
         :ensure => :present,
         :mode => '644',
-        :content => template(File.join(File.dirname(__FILE__), '..', 'templates', 'mongodb.conf.erb'), binding),
-        :before => service('mongodb'),
-        :notify => service('mongodb')
+        :content => template(File.join(File.dirname(__FILE__), '..', 'templates', "#{mongod_name}.conf.erb"), binding),
+        :before => service("#{mongod_name}"),
+        :notify => service("#{mongod_name}")
 
-      file '/etc/init/mongodb.conf',
+      file "/etc/init/#{mongod_name}.conf",
         :ensure => :present,
         :mode => '644',
-        :content => template(File.join(File.dirname(__FILE__), '..', 'templates', 'mongodb.upstart.erb'), binding),
-        :before => service('mongodb')
+        :content => template(File.join(File.dirname(__FILE__), '..', 'templates', "#{mongod_name}.upstart.erb"), binding),
+        :before => service("#{mongod_name}")
 
-      file '/etc/init.d/mongodb',
+      file "/etc/init.d/#{mongod_name}",
         :ensure => :link, :target => '/lib/init/upstart-job',
-        :before => service('mongodb')
+        :before => service("#{mongod_name}")
 
-      service 'mongodb',
+      service "#{mongod_name}",
         :ensure => :running,
-        :status => 'initctl status mongodb | grep running',
-        :start => 'initctl start mongodb',
-        :stop => 'initctl stop mongodb',
-        :restart => 'initctl restart mongodb',
+        :status => "initctl status #{mongod_name} | grep running",
+        :start => "initctl start #{mongod_name}",
+        :stop => "initctl stop #{mongod_name}",
+        :restart => "initctl restart #{mongod_name}",
         :provider => :base,
         :enable => true,
         :require => [
           package('mongodb'),
-          file('/etc/mongodb.conf'),
-          file('/etc/init/mongodb.conf'),
+          file("/etc/#{mongod_name}.conf"),
+          file("/etc/init/#{mongod_name}.conf"),
         ],
         :before => exec('rake tasks')
     end

--- a/lib/mongodb.rb
+++ b/lib/mongodb.rb
@@ -166,6 +166,10 @@ module Mongodb
   end
 
   private
+  def ubuntu_trusty?
+    Facter.value(:lsbdistid) == 'Ubuntu' && Facter.value(:lsbdistrelease).to_f == 14.04
+  end
+
   def ubuntu_precise?
     Facter.value(:lsbdistid) == 'Ubuntu' && Facter.value(:lsbdistrelease).to_f == 12.04
   end

--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -1,0 +1,85 @@
+# mongod.conf
+
+# Where to store the data.
+
+# Note: if you run mongodb as a non-root user (recommended) you may
+# need to create and set permissions for this directory manually,
+# e.g., if the parent directory isn't mutable by the mongodb user.
+dbpath = <%= options[:dbpath] %>
+
+#where to log
+logpath = <%= options[:logpath] %>/mongodb.log
+logappend=true
+
+port = <%= options[:port] %>
+bind_ip = <%= options[:bind_ip] %>
+
+# Disables write-ahead journaling
+# nojournal = true
+
+# Enables periodic logging of CPU utilization and I/O wait
+<% if options[:cpu_logging] %>
+cpu = true
+<% else %>
+# cpu = true
+<% end %>
+
+# Turn on/off security.  Off is currently the default
+#noauth = true
+#auth = true
+
+# Verbose logging output.
+<% if options[:verbose] %>
+verbose = true
+<% else %>
+#verbose = true
+<% end %>
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+diaglog = <%= options[:loglevel] %>
+
+# Ignore query hints
+#nohints = true
+
+# Enable the HTTP interface (Defaults to port 28017).
+#httpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Replication Options
+
+# in replica set configuration, specify the name of the replica set
+<% if options[:replset] %>
+replSet = <%= options[:replset] %>
+<% else %>
+# replSet = setname
+<% end %>
+
+# maximum size in megabytes for replication operation log
+#oplogSize=1024
+# path to a key file storing authentication info for connections
+# between replica set members
+#keyFile=/path/to/keyfile

--- a/templates/mongod.upstart.erb
+++ b/templates/mongod.upstart.erb
@@ -1,0 +1,47 @@
+# Ubuntu upstart file at /etc/init/mongod.conf
+
+limit fsize unlimited unlimited
+limit cpu unlimited unlimited
+limit as unlimited unlimited
+limit nofile 64000 64000
+limit rss unlimited unlimited
+limit nproc 32000 32000
+
+kill timeout 300 # wait 300s between SIGTERM and SIGKILL.
+
+pre-start script
+    mkdir -p <%= options[:dbpath] %>
+    mkdir -p <%= options[:logpath] %>
+end script
+
+start on runlevel [2345]
+stop on runlevel [06]
+
+respawn
+respawn limit 5 30
+
+script
+  ENABLE_MONGOD="yes"
+  CONF=/etc/mongod.conf
+  DAEMON=/usr/bin/mongod
+  DAEMONUSER=${DAEMONUSER:-mongodb}
+
+  if [ -f /etc/default/mongod ]; then . /etc/default/mongod; fi
+
+  # Handle NUMA access to CPUs (SERVER-3574)
+  # This verifies the existence of numactl as well as testing that the command works
+  NUMACTL_ARGS="--interleave=all"
+  if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
+  then
+    NUMACTL="$(which numactl) -- $NUMACTL_ARGS"
+    DAEMON_OPTS=${DAEMON_OPTS:-"--config $CONF"}
+  else
+    NUMACTL=""
+    DAEMON_OPTS="-- "${DAEMON_OPTS:-"--config $CONF"}
+  fi
+
+  if [ "x$ENABLE_MONGOD" = "xyes" ]
+  then
+    exec start-stop-daemon --start --quiet --chuid $DAEMONUSER --exec $NUMACTL $DAEMON $DAEMON_OPTS
+  fi
+end script


### PR DESCRIPTION
Updates for the plugin to work properly with Mongodb 2.6.x, including templates for mongod. Trusty support had been started, but the ubuntu_trusty? method was missing from the code.